### PR TITLE
🛠 Dynamic extra Chromium flags

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,4 +29,5 @@ fi
   --remote-debugging-port=9222 \
   --safebrowsing-disable-auto-update \
   --disable-gpu \
-  --user-data-dir=/home/chromium/
+  --user-data-dir=/home/chromium/ \
+  "$@"


### PR DESCRIPTION
Fix #4 

Now extra flags could be added through the entrypoint, so we could do something like this:

```sh
docker run -it --rm -p 9222:9222 \
    deepsweet/chromium-headless-remote:76 \
    --window-size=1024,768
```