### PR TITLE
update to Chromium 77.0.3865.90

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,20 @@
-FROM ubuntu:disco
+FROM ubuntu:bionic
+
+# Run `make show-versions` to see latest versions
+# Pick one that's higher than one below and paste here.
+# Because actual package versions are long: '77.0.3865.90-0ubuntu0.18.04.1'
+# we use wildcard.
+# Match the value here to that assigned to TAGS variable inside Makefile.
+# Commit both changes, run `make push-tags` and wait for Docker Hub to build new images.
+ARG CHROMIUM_VERSION=77.0.3865.90\*
 
 RUN apt-get update && \
-    apt-get --no-install-recommends --yes install chromium-browser=76\* dumb-init fontconfig && \
+    apt-get --no-install-recommends --yes install \
+        chromium-browser=${CHROMIUM_VERSION} \
+        dumb-init \
+        fontconfig \
+    && \
+    rm -rf /var/lib/apt/lists/* && \
     groupadd chromium && \
     useradd --create-home --gid chromium chromium && \
     chown --recursive chromium:chromium /home/chromium/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Docker Hub's Auto Builder is used to create versioned builds.
+# Build instructions are set to look at tag value and create an image tag
+# with same exact tag.
+# For that reason we CANNOT use parameterized Dockerfile, and, instead,
+# are using multiple Git Tags to point to same exact Git commit.
+# (if there is a better way to Auto Build multiple image tags off same commit, suggest how)
+
+# To bump the build version:
+# 1. Run `make show-versions`
+# 2. Pick newer version and paste here and in Dockerfile (properly shortening it)
+# 3. Commit changes to this and Dockerfile files
+# 4. Run `make tags`
+# 5. Run `make push-tags` to push ALL new tags up
+
+show-versions:
+	docker run -it --rm \
+		ubuntu:bionic \
+		bash -c "apt-get update && apt-cache policy chromium-browser"
+
+# Run `make show-versions` to see latest versions
+# Pick one that's higher than one below and paste here.
+# Because actual package versions are long: '77.0.3865.90-0ubuntu0.18.04.1'
+# we use wildcard in Dockerfile and shorten it here.
+# Match the value here to that assigned to CHROMIUM_VERSION variable inside Dockerfile.
+# Commit both changes, run `make push-tags` and wait for Docker Hub to build new images.
+TAGS:=77.0.3865.90 77.0.3865 77.0 77
+
+tags:
+	for TAG in $(TAGS) ; do \
+		git tag -d $$TAG || true ; \
+	done
+	for TAG in $(TAGS) ; do \
+		git tag $$TAG ; \
+	done
+
+push-tags:
+	for TAG in $(TAGS) ; do \
+		git push --delete origin $$TAG ; \
+	done
+	git push origin --tags

--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,8 @@ Dockerized Chromium in [headless](https://chromium.googlesource.com/chromium/src
 ## Usage
 
 ```sh
-docker pull deepsweet/chromium-headless-remote:76
-docker run -it --rm -p 9222:9222 deepsweet/chromium-headless-remote:76
+docker pull deepsweet/chromium-headless-remote:77
+docker run -it --rm -p 9222:9222 deepsweet/chromium-headless-remote:77
 ```
 
 Example using [Puppeteer](https://github.com/GoogleChrome/puppeteer):

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,12 @@ docker run -it --rm -p 9222:9222 deepsweet/chromium-headless-remote:77
 
 Example using [Puppeteer](https://github.com/GoogleChrome/puppeteer):
 
+Ensure to match version of `puppeteer-core` to the version of Chromium you are using:
+
+```sh
+npm install puppeteer-core@chrome-77
+```
+
 ```js
 import puppeteer from 'puppeteer-core'
 import request from 'request-promise-native'


### PR DESCRIPTION
- switch to more specific, 77.x version of chromium
- add `rm -rf /var/lib/apt/lists/* && \` to shave off ~26mb off the image
- switch to more stable base image - `bionic` (more chance of its base to be on user's machine)
- add sugar for generating and publishing tags for the build (to leverage Docker Hub's Auto Build logic)

Tested auto-builds with https://cloud.docker.com/repository/docker/ddotsenko/chromium-headless-remote/builds